### PR TITLE
docs: fix simple typo, seperators -> separators

### DIFF
--- a/[教程] [本人] Counterstrike Global Offensive/Q.hvh陀螺自瞄/bsp_parser.hpp
+++ b/[教程] [本人] Counterstrike Global Offensive/Q.hvh陀螺自瞄/bsp_parser.hpp
@@ -1009,7 +1009,7 @@ namespace rn {
 		{
 			static auto fix_seperators = [](const std::string& input)
 			{
-				// convert seperators from DOS to UNIX
+				// convert separators from DOS to UNIX
 				return std::filesystem::path(input).generic_string();
 			};
 


### PR DESCRIPTION
There is a small typo in [教程] [本人] Counterstrike Global Offensive/Q.hvh陀螺自瞄/bsp_parser.hpp.

Should read `separators` rather than `seperators`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md